### PR TITLE
설정 화면_개인정보 설정(비밀번호 입력창 까지), 버전정보 화면 구현

### DIFF
--- a/HikingClub/Feature/Settings/PersonalInformationMenu/PersonalInformationViewController.swift
+++ b/HikingClub/Feature/Settings/PersonalInformationMenu/PersonalInformationViewController.swift
@@ -1,0 +1,112 @@
+//
+//  PersonalInformationViewController.swift
+//  HikingClub
+//
+//  Created by 이문정 on 2021/11/13.
+//
+
+import UIKit
+
+class PersonalInformationViewController: BaseViewController<PersonalInformationViewModel>, ScrollViewKeyboardApperanceProtocol{
+    private let navigationBar: NaviBar = {
+        let view = NaviBar(frame: .zero)
+        view.setTitle("개인정보 설정")
+        view.setBackItemImage()
+        return view
+    }()
+    
+    var scrollView = UIScrollView()
+    
+    var bottomAreaView: UIView {
+        nextButton // 버튼 attribute
+    }
+    
+    private let scrollContentsView = UIView()
+    
+    private let textFieldStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.spacing = 48
+        stackView.isLayoutMarginsRelativeArrangement = false
+        stackView.layoutMargins = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
+        return stackView
+    }()
+    
+    private let passwordTextfield: NDTextFieldView = {
+        let textfield = NDTextFieldView(scale: .big)
+        textfield.setTitle("비밀번호", description: "6~18자의 비밀번호", theme: .normal)
+        textfield.setTitle("비밀번호", description: "비밀번호는 6~18자로 입력해야합니다.", theme: .warning)
+        textfield.setPasswordMode()
+        textfield.setTheme(.normal)
+        return textfield
+    }()
+    
+    private let nextButton: NDCTAButton = {
+        let button = NDCTAButton(buttonStyle: .one)
+        button.setTitle("확인", buttonType: .ok)
+        button.setEnabled(false, type: .ok)
+        return button
+    }()
+    
+    override func layout() {
+        super.layout()
+        view.addSubViews(navigationBar, scrollView, nextButton)
+        navigationBar.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.leading.trailing.equalToSuperview()
+        }
+        scrollView.snp.makeConstraints {
+            $0.top.equalTo(navigationBar.snp.bottom)
+            $0.leading.trailing.equalToSuperview()
+            
+        }
+        nextButton.snp.makeConstraints {
+            $0.top.equalTo(scrollView.snp.bottom)
+            $0.leading.trailing.equalToSuperview()
+            $0.bottom.equalTo(view)
+        }
+        scrollView.addSubview(scrollContentsView)
+        scrollContentsView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+            
+            $0.width.equalTo(view)
+        }
+        
+        scrollContentsViewLayout()
+    }
+    
+    private func scrollContentsViewLayout() {
+        scrollContentsView.addSubview(textFieldStackView)
+        textFieldStackView.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(48)
+            $0.leading.equalToSuperview().offset(16)
+            $0.trailing.equalToSuperview().inset(16)
+            $0.bottom.equalToSuperview()
+        }
+        textFieldStackViewLayout()
+    }
+    
+    private func textFieldStackViewLayout() {
+        textFieldStackView.addArrangedSubviews(passwordTextfield)
+    }
+    override func bind() {
+        super.bind()
+        navigationBar.rx.tapLeftItem
+            .subscribe(onNext: { [weak self] in
+                self?.navigationController?.popViewController(animated: true)
+            })
+            .disposed(by: disposeBag)
+        
+//        passwordTextfield.rx.text
+//            .skip(1)
+//            .filter { !$0.isEmpty }
+//            .subscribe(onNext: { [weak self] in
+//                guard let isValidate = self?.viewModel.isValidatePassword($0) else { return }
+//                self?.passwordTextfield.setTheme(isValidate ? .normal : .warning)
+//            })
+//            .disposed(by: disposeBag)
+    }
+//    private func navigateToInitialSettingViewController() {
+//        navigationController?.pushViewController(InitialSettingViewController(BaseViewModel()), animated: true)
+//    }
+}

--- a/HikingClub/Feature/Settings/PersonalInformationMenu/PersonalInformationViewModel.swift
+++ b/HikingClub/Feature/Settings/PersonalInformationMenu/PersonalInformationViewModel.swift
@@ -1,0 +1,13 @@
+//
+//  PersonalInformationViewModel.swift
+//  HikingClub
+//
+//  Created by 이문정 on 2021/11/13.
+//
+
+import Foundation
+import RxRelay
+
+final class PersonalInformationViewModel: BaseViewModel {
+    
+}

--- a/HikingClub/Feature/Settings/SettingViewController.swift
+++ b/HikingClub/Feature/Settings/SettingViewController.swift
@@ -94,5 +94,27 @@ final class SettingViewController: BaseViewController<BaseViewModel> {
                 self?.navigationController?.popViewController(animated: true)
             })
             .disposed(by: disposeBag)
+        
+        versionMenu.rx.tap
+            .subscribe(onNext: { [weak self] in
+                let versionInfoStoryboard = UIStoryboard(name: "VersionInfo", bundle: nil)
+                let versionInfoViewContoller = versionInfoStoryboard.instantiate("VersionInfoViewController") { coder -> VersionInfoViewController in
+                        .init(coder,BaseViewModel()) ?? VersionInfoViewController(BaseViewModel())
+                }
+                self?.navigationController?.pushViewController(versionInfoViewContoller, animated: true)
+            })
+            .disposed(by: disposeBag)
+        
+        personalInformationMenu.rx.tap
+            .subscribe(onNext: { [weak self] in
+                self?.navigateToPersonalInformationMenu()
+            })
+            .disposed(by: disposeBag)
+        
     }
+    
+    private func navigateToPersonalInformationMenu() {
+        navigationController?.pushViewController(PersonalInformationViewController(PersonalInformationViewModel()), animated: true)
+    }
+    
 }

--- a/HikingClub/Feature/Settings/UserInfoSetting.storyboard
+++ b/HikingClub/Feature/Settings/UserInfoSetting.storyboard
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17150" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17122"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="s0d-6b-0kx">
+            <objects>
+                <viewController id="Y6W-OH-hqX" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/HikingClub/Feature/Settings/VersionInfoMenu/VersionInfo.storyboard
+++ b/HikingClub/Feature/Settings/VersionInfoMenu/VersionInfo.storyboard
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Version Info View Controller-->
+        <scene sceneID="s0d-6b-0kx">
+            <objects>
+                <viewController storyboardIdentifier="VersionInfoViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="Y6W-OH-hqX" customClass="VersionInfoViewController" customModule="HikingClub" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="최신 버전을 사용중입니다." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fqF-Uq-ehN">
+                                <rect key="frame" x="114.5" y="354" width="185.5" height="21"/>
+                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="18"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="현재버전 1.0.2" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FdZ-1z-9a3">
+                                <rect key="frame" x="165.5" y="391" width="83" height="17"/>
+                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="14"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Z9f-5v-2nU" customClass="NDButton" customModule="HikingClub" customModuleProvider="target">
+                                <rect key="frame" x="35.5" y="808" width="343" height="54"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="343" id="J98-D9-PVm"/>
+                                    <constraint firstAttribute="height" constant="54" id="kbb-BF-K6c"/>
+                                </constraints>
+                            </view>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="fqF-Uq-ehN" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="Lkt-1T-JlM"/>
+                            <constraint firstItem="Z9f-5v-2nU" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="MUY-zq-wew"/>
+                            <constraint firstItem="fqF-Uq-ehN" firstAttribute="top" secondItem="5EZ-qb-Rvc" secondAttribute="top" constant="354" id="SBT-l0-pND"/>
+                            <constraint firstItem="FdZ-1z-9a3" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="Vfs-0S-hAr"/>
+                            <constraint firstAttribute="bottom" secondItem="Z9f-5v-2nU" secondAttribute="bottom" constant="34" id="WN7-aF-kW8"/>
+                            <constraint firstItem="FdZ-1z-9a3" firstAttribute="top" secondItem="fqF-Uq-ehN" secondAttribute="bottom" constant="16" id="xP0-Tw-y6S"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="presentVersionLable" destination="FdZ-1z-9a3" id="BFN-w1-2mY"/>
+                        <outlet property="versionCommentLabel" destination="fqF-Uq-ehN" id="WmJ-iw-GxC"/>
+                        <outlet property="versionUpdateButtonView" destination="Z9f-5v-2nU" id="rJT-fG-XDd"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="13" y="76"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/HikingClub/Feature/Settings/VersionInfoMenu/VersionInfoViewController.swift
+++ b/HikingClub/Feature/Settings/VersionInfoMenu/VersionInfoViewController.swift
@@ -1,0 +1,67 @@
+//
+//  VersionInfoViewController.swift
+//  HikingClub
+//
+//  Created by 이문정 on 2021/11/06.
+//
+
+import UIKit
+import RxCocoa
+import RxSwift
+
+class VersionInfoViewController: BaseViewController<BaseViewModel> {
+    
+    @IBOutlet weak var versionCommentLabel: UILabel!
+    @IBOutlet weak var presentVersionLable: UILabel!
+    @IBOutlet weak var versionUpdateButtonView: NDButton!
+    
+    private let navigationBar: NaviBar = {
+        let view = NaviBar()
+        view.setTitle("버전정보")
+        view.setBackItemImage()
+        return view
+    }()
+    
+    func updateButton() {
+        versionUpdateButtonView.setTitle("업데이트 하기", for: .normal)
+        versionUpdateButtonView.snp.makeConstraints {
+            $0.height.equalTo(54)
+        }
+        versionUpdateButtonView.isEnabled = false
+        versionUpdateButtonView.rx.tap
+            .subscribe(onNext: { [weak self] in
+                print("버튼 클릭!")
+            })
+            .disposed(by: disposeBag)
+        // 뷰모델에서 업데이트 정보 받아서 버튼 활성화
+        Observable.just(true)
+            .bind(to: versionUpdateButtonView.rx.isEnabled)
+            .disposed(by: disposeBag)
+    }
+    
+    override func attribute() {
+        updateButton()
+        versionCommentLabel.textColor = .gray800
+        versionCommentLabel.setFont(.semiBold18)
+        presentVersionLable.textColor = .gray500
+        presentVersionLable.setFont(.medium14)
+    }
+    
+    override func layout() {
+        super.layout()
+        view.addSubViews(navigationBar)
+        navigationBar.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.leading.trailing.equalToSuperview()
+        }
+    }
+    
+    override func bind() {
+        super.bind()
+        navigationBar.rx.tapLeftItem
+            .subscribe(onNext: { [weak self] in
+                self?.navigationController?.popViewController(animated: true)
+            })
+            .disposed(by: disposeBag)
+    }
+}

--- a/HikingClub/Feature/Settings/VersionInfoMenu/VersionInfoViewModel.swift
+++ b/HikingClub/Feature/Settings/VersionInfoMenu/VersionInfoViewModel.swift
@@ -1,0 +1,13 @@
+//
+//  VersionInfoViewModel.swift
+//  HikingClub
+//
+//  Created by 이문정 on 2021/11/13.
+//
+
+import Foundation
+import RxRelay
+
+final class VersionInfoViewModel: BaseViewModel {
+    let versionInfo: BehaviorRelay<[String]> = BehaviorRelay(value: [])
+}


### PR DESCRIPTION
<!-- 필요하지 않은 항목 삭제하기 -->
## 이슈번호 
#53 
## 작업내용
* 설정화면_개인정보 설정(비밀번호 입력창 까지) 화면 구현
* 설정화면_버전정보 화면 구현
## 스크린샷
* 개인정보 설정_비밀번호 입력 
<img width="232" alt="스크린샷 2021-11-14 오전 4 03 42" src="https://user-images.githubusercontent.com/73117833/141656133-db1b3cff-09f0-4a75-8b16-64eda5b9bf17.png">
* 버전정보 화면 
<img width="233" alt="스크린샷 2021-11-14 오전 4 01 47" src="https://user-images.githubusercontent.com/73117833/141656062-2e53e152-d4a8-4523-afdd-1cedf3860ec4.png">


