### PR TITLE
유저정보(토큰) 통합관리

### DIFF
--- a/HikingClub.xcodeproj/project.pbxproj
+++ b/HikingClub.xcodeproj/project.pbxproj
@@ -133,6 +133,7 @@
 		777B517E2714336700299430 /* InitialSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 777B517D2714336700299430 /* InitialSettingViewController.swift */; };
 		777B51802714472B00299430 /* TermDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 777B517F2714472B00299430 /* TermDetailViewController.swift */; };
 		777B51852714553600299430 /* InitialCategorySettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 777B51842714553600299430 /* InitialCategorySettingViewController.swift */; };
+		7784885D274D18DE00437D51 /* UserInformationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7784885C274D18DE00437D51 /* UserInformationManager.swift */; };
 		779B94FB2745557100325353 /* TermDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 779B94FA2745557100325353 /* TermDetailViewModel.swift */; };
 		779B94FE27467D8C00325353 /* SignUpRequestModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 779B94FD27467D8C00325353 /* SignUpRequestModel.swift */; };
 		779B950227467E0600325353 /* EmailVerifiactionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 779B950127467E0600325353 /* EmailVerifiactionService.swift */; };
@@ -280,6 +281,7 @@
 		777B517D2714336700299430 /* InitialSettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InitialSettingViewController.swift; sourceTree = "<group>"; };
 		777B517F2714472B00299430 /* TermDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermDetailViewController.swift; sourceTree = "<group>"; };
 		777B51842714553600299430 /* InitialCategorySettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InitialCategorySettingViewController.swift; sourceTree = "<group>"; };
+		7784885C274D18DE00437D51 /* UserInformationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInformationManager.swift; sourceTree = "<group>"; };
 		779B94FA2745557100325353 /* TermDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermDetailViewModel.swift; sourceTree = "<group>"; };
 		779B94FD27467D8C00325353 /* SignUpRequestModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpRequestModel.swift; sourceTree = "<group>"; };
 		779B950127467E0600325353 /* EmailVerifiactionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailVerifiactionService.swift; sourceTree = "<group>"; };
@@ -604,6 +606,7 @@
 				777B516D27119A7100299430 /* CodeBased */,
 				06A1EC9127089D2700EA78D8 /* Extension */,
 				777B517127129D4D00299430 /* Protocol */,
+				7784885B274D18C600437D51 /* Manager */,
 			);
 			path = Helper;
 			sourceTree = "<group>";
@@ -835,6 +838,14 @@
 				7761AC0A273D641E0029BCF2 /* InitialCategorySettingViewModel.swift */,
 			);
 			path = InitialSetting;
+			sourceTree = "<group>";
+		};
+		7784885B274D18C600437D51 /* Manager */ = {
+			isa = PBXGroup;
+			children = (
+				7784885C274D18DE00437D51 /* UserInformationManager.swift */,
+			);
+			path = Manager;
 			sourceTree = "<group>";
 		};
 		779B94F92745556400325353 /* Term */ = {
@@ -1106,6 +1117,7 @@
 				7760CA96272541D0006B39A9 /* Encodable+.swift in Sources */,
 				7760CA8D27252ED2006B39A9 /* EmailAuthorizeViewModel.swift in Sources */,
 				773DF08E2737A2AB0025DC91 /* SelectTownViewModel.swift in Sources */,
+				7784885D274D18DE00437D51 /* UserInformationManager.swift in Sources */,
 				06D4FF2A27390A8400300AE5 /* UserDefault+.swift in Sources */,
 				06679F09271EB3E500D63AE1 /* NDCTAButton.swift in Sources */,
 				77E59135270DDFCF0070F381 /* WebViewModel.swift in Sources */,

--- a/HikingClub/Feature/Settings/SettingViewModel.swift
+++ b/HikingClub/Feature/Settings/SettingViewModel.swift
@@ -13,7 +13,7 @@ final class SettingViewModel: BaseViewModel {
     let signOutSucceedRelay = PublishRelay<Void>()
 
     func signOut() {
-        UserInformationUserDefault.init(key: .token).removeAll()
+        UserInformationManager.shared.singOut()
         signOutSucceedRelay.accept(Void())
     }
 }

--- a/HikingClub/Feature/WebView/BaseWebView.swift
+++ b/HikingClub/Feature/WebView/BaseWebView.swift
@@ -39,7 +39,7 @@ final class BaseWebView: WKWebView {
     
     func setUserTokenAtCookie() {
         guard
-            let token = UserInformationUserDefault.init(key: .token).value,
+            let token = UserInformationManager.shared.token,
             let cookie = makeUserTokenCookie(token)
         else { return }
         configuration.websiteDataStore.httpCookieStore.setCookie(cookie)

--- a/HikingClub/Helper/Manager/UserInformationManager.swift
+++ b/HikingClub/Helper/Manager/UserInformationManager.swift
@@ -7,27 +7,29 @@
 
 import RxRelay
 
-struct UserInformationManager {
+final class UserInformationManager {
     static let shared = UserInformationManager()
+    
+    private let userDefault = UserInformationUserDefault.init(key: .token)
     
     private init() { }
     
     var isSingIn: Bool {
-        UserInformationUserDefault.init(key: .token).isEmpty
+        userDefault.isEmpty
     }
     
     var token: String? {
-        UserInformationUserDefault.init(key: .token).value
+        userDefault.value
     }
     
     var isSignedOut = PublishRelay<Void>()
     
     func signIn(_ token: String) {
-        UserInformationUserDefault.init(key: .token).save(token)
+        userDefault.save(token)
     }
     
     func singOut() {
-        UserInformationUserDefault.init(key: .token).removeAll()
+        userDefault.removeAll()
         isSignedOut.accept(Void())
     }
 }

--- a/HikingClub/Helper/Manager/UserInformationManager.swift
+++ b/HikingClub/Helper/Manager/UserInformationManager.swift
@@ -1,0 +1,33 @@
+//
+//  UserInformationManager.swift
+//  HikingClub
+//
+//  Created by AhnSangHoon on 2021/11/23.
+//
+
+import RxRelay
+
+struct UserInformationManager {
+    static let shared = UserInformationManager()
+    
+    private init() { }
+    
+    var isSingIn: Bool {
+        UserInformationUserDefault.init(key: .token).isEmpty
+    }
+    
+    var token: String? {
+        UserInformationUserDefault.init(key: .token).value
+    }
+    
+    var isSignedOut = PublishRelay<Void>()
+    
+    func signIn(_ token: String) {
+        UserInformationUserDefault.init(key: .token).save(token)
+    }
+    
+    func singOut() {
+        UserInformationUserDefault.init(key: .token).removeAll()
+        isSignedOut.accept(Void())
+    }
+}


### PR DESCRIPTION
<!-- 필요하지 않은 항목 삭제하기 -->
## 작업내용 
* signOut의 상태가 되면 처리해야되는 로직이 있는 ViewController들이 존재함, (MyPageViewController의 데이터 리셋 등)
   따라서 signIn 상태를 관리하는 Manager객체를 만듦.
## 변경사항
* 기존의 `UserInformationUserDetault.init(key: .token)`의 코드를 모두 Manager에 옮김.
