### PR TITLE
로그인 네비게이션 페이지에서 다른 화면 진입시 로띠 멈춤 현상 해결

### DIFF
--- a/HikingClub/Feature/Login/LoginNavigationViewController.swift
+++ b/HikingClub/Feature/Login/LoginNavigationViewController.swift
@@ -17,15 +17,11 @@ final class LoginNavigationViewController: BaseViewController<LoginNavigationVie
         return stackView
     }()
     
-    private let lottieView: UIView = {
-        let view = UIView()
+    private let lottieView: AnimationView = {
         let animationView = AnimationView(name: "lottie_start")
-        view.addSubview(animationView)
-        animationView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
-        }
+        animationView.backgroundBehavior = .pauseAndRestore
         animationView.play()
-        return view
+        return animationView
     }()
     
     private let signUpButton: NDButton = {


### PR DESCRIPTION
<!-- 필요하지 않은 항목 삭제하기 -->
## 작업내용 
* 로그인 네비게이션 페이지에서 다른 화면 진입 시 로띠 멈춤 현상 해결
## 변경사항
* AnimationView의 `backgroundBehavior` Property 를 `.pauseAndRestore`로 설정
