### PR TITLE
[Bug] 약관 동의 후, 약관페이지를 통한 약관동의 시 상태 업데이트 안되던 현상 대응

### DIFF
--- a/HikingClub/Feature/Login/SignUp/SignUpViewController.swift
+++ b/HikingClub/Feature/Login/SignUp/SignUpViewController.swift
@@ -124,7 +124,9 @@ final class SignUpViewController: BaseViewController<SignUpViewModel> {
         let viewModel = TermDetailViewModel()
         viewModel.agreementRelay
             .subscribe(onNext: { [weak self] _ in
-                self?.termStackView.didAgree.accept(.personal)
+                if false == self?.viewModel.isEnableSignUp ?? false {
+                    self?.termStackView.didAgree.accept(.personal)
+                }
             })
             .disposed(by: disposeBag)
         let viewController = TermDetailViewController(viewModel)


### PR DESCRIPTION
<!-- 필요하지 않은 항목 삭제하기 -->
## 이슈번호
 #112 
## 작업내용
* 약관 동의 후, 약관페이지를 통한 약관동의 시 상태 업데이트 안되던 현상 대응
## 변경사항
* 약관 동의 후 상태 업데이트 시, 업데이트가 필요 없는 상황이라면 업데이트 하지 않도록 변경
