### PR TITLE
[Refactor] ViewModel에서 ToastMessage 노출 로직 변경

### DIFF
--- a/HikingClub/Feature/ChangePassword/ChangePasswordViewModel.swift
+++ b/HikingClub/Feature/ChangePassword/ChangePasswordViewModel.swift
@@ -71,12 +71,12 @@ final class ChangePasswordViewModel: BaseViewModel {
             .subscribe(onSuccess: { [weak self] response in
                 if response.responseCode == "SUCCESS_RESET_PASSWORD" {
                     self?.changePasswordSucceedRelay.accept(Void())
-                    NDToastView.shared.rx.showText.onNext(.green(text: response.message))
+                    self?.toastMessage.accept(.green(text: response.message))
                 } else {
-                    NDToastView.shared.rx.showText.onNext(.red(text: response.message))
+                    self?.toastMessage.accept(.red(text: response.message))
                 }
-            }, onFailure: { _ in
-                NDToastView.shared.rx.showText.onNext(.red(text: "네트워크 오류가 발생했습니다."))
+            }, onFailure: { [weak self] _ in
+                self?.toastMessage.accept(.red(text: "네트워크 오류가 발생했습니다."))
             })
             .disposed(by: disposeBag)
     }

--- a/HikingClub/Feature/Login/SignIn/SignInViewModel.swift
+++ b/HikingClub/Feature/Login/SignIn/SignInViewModel.swift
@@ -19,13 +19,13 @@ final class SignInViewModel: BaseViewModel {
                 if response.responseCode ==  "SUCCESS_LOGIN" {
                     guard let responseData = response.data else { return }
                     UserInformationManager.shared.signIn(responseData.accessToken)
-                    NDToastView.shared.rx.showText.onNext(.green(text: response.message))
+                    self?.toastMessage.accept(.green(text: response.message))
                     self?.loginSucceededRelay.accept(Void())
                 } else {
-                    NDToastView.shared.rx.showText.onNext(.red(text: response.message))
+                    self?.toastMessage.accept(.red(text: response.message))
                 }
-            }, onFailure: { _ in
-                NDToastView.shared.rx.showText.onNext(.red(text: "네트워크 오류가 발생했습니다."))
+            }, onFailure: { [weak self] _ in
+                self?.toastMessage.accept(.red(text: "네트워크 오류가 발생했습니다."))
             })
             .disposed(by: disposeBag)
     }

--- a/HikingClub/Feature/Login/SignUp/EmailAuthorize/EmailAuthorizeViewModel.swift
+++ b/HikingClub/Feature/Login/SignUp/EmailAuthorize/EmailAuthorizeViewModel.swift
@@ -38,30 +38,28 @@ class EmailAuthorizeViewModel: BaseViewModel {
     
     private func sendEmailForSingUp(_ email: String) {
         emailService.sendToken(email)
-            .subscribe(onSuccess: { response in
+            .subscribe(onSuccess: { [weak self] response in
                 if response.responseCode == "SUCCESS_SEND_MAIL_SIGN_UP_TOKEN" {
-                    NDToastView.shared.rx.showText.onNext(.green(text: "인증메일이 전송되었습니다."))
+                    self?.toastMessage.accept(.green(text: "인증메일이 전송되었습니다."))
                 } else {
-                    let message = response.message
-                    NDToastView.shared.rx.showText.onNext(.red(text: message))
+                    self?.toastMessage.accept(.red(text: response.message))
                 }
-            }, onFailure: { _ in
-                NDToastView.shared.rx.showText.onNext(.red(text: "네트워크 오류가 발생했습니다."))
+            }, onFailure: { [weak self] _ in
+                self?.toastMessage.accept(.red(text: "네트워크 오류가 발생했습니다."))
             })
             .disposed(by: disposeBag)
     }
     
     private func sendEmailForChangePassword(_ email: String) {
         userService.requestChangePassword(for: email)
-            .subscribe(onSuccess: { response in
+            .subscribe(onSuccess: { [weak self] response in
                 if response.responseCode == "SUCCESS_REQUEST_RESET_PASSWORD" {
-                    NDToastView.shared.rx.showText.onNext(.green(text: "인증메일이 전송되었습니다."))
+                    self?.toastMessage.accept(.green(text: "인증메일이 전송되었습니다."))
                 } else {
-                    let message = response.message
-                    NDToastView.shared.rx.showText.onNext(.red(text: message))
+                    self?.toastMessage.accept(.green(text: response.message))
                 }
-            }, onFailure: { _ in
-                NDToastView.shared.rx.showText.onNext(.red(text: "네트워크 오류가 발생했습니다."))
+            }, onFailure: { [weak self] _ in
+                self?.toastMessage.accept(.red(text: "네트워크 오류가 발생했습니다."))
             })
             .disposed(by: disposeBag)
     }
@@ -74,11 +72,10 @@ class EmailAuthorizeViewModel: BaseViewModel {
                 if response.responseCode == "SUCCESS_VERIFYING" {
                     self?.authorizeSucceedRelay.accept(email)
                 } else {
-                    let message = response.message
-                    NDToastView.shared.rx.showText.onNext(.red(text: message))
+                    self?.toastMessage.accept(.green(text: response.message))
                 }
-            }, onFailure: { _ in
-                NDToastView.shared.rx.showText.onNext(.red(text: "네트워크 오류가 발생했습니다."))
+            }, onFailure: { [weak self] _ in
+                self?.toastMessage.accept(.red(text: "네트워크 오류가 발생했습니다."))
             })
             .disposed(by: disposeBag)
     }

--- a/HikingClub/Feature/Login/SignUp/InitialSetting/InitialSettingViewModel.swift
+++ b/HikingClub/Feature/Login/SignUp/InitialSetting/InitialSettingViewModel.swift
@@ -24,21 +24,21 @@ final class InitialSettingViewModel: BaseViewModel {
                 if response.responseCode == "SUCCESS_SIGN_UP" {
                     self?.signInProcess(response)
                 } else {
-                    NDToastView.shared.rx.showText.onNext(.red(text: response.message))
+                    self?.toastMessage.accept(.red(text: response.message))
                 }
-            }, onFailure: { _ in
-                NDToastView.shared.rx.showText.onNext(.red(text: "네트워크 오류가 발생했습니다."))
+            }, onFailure: { [weak self] _ in
+                self?.toastMessage.accept(.red(text: "네트워크 오류가 발생했습니다."))
             })
             .disposed(by: disposeBag)
     }
     
     private func signInProcess(_ response: ResponseModel<SignUpResponseModel>) {
         guard let token = response.data?.accessToken else {
-            NDToastView.shared.rx.showText.onNext(.red(text: "네트워크 오류가 발생했습니다."))
+            toastMessage.accept(.red(text: "네트워크 오류가 발생했습니다."))
             return
         }
         UserInformationManager.shared.signIn(token)
-        NDToastView.shared.rx.showText.onNext(.green(text: response.message))
+        toastMessage.accept(.green(text: response.message))
         
         signUpSucceedRelay.accept(Void())
     }

--- a/HikingClub/Feature/Login/SignUp/SignUpViewController.swift
+++ b/HikingClub/Feature/Login/SignUp/SignUpViewController.swift
@@ -124,7 +124,9 @@ final class SignUpViewController: BaseViewController<SignUpViewModel> {
         let viewModel = TermDetailViewModel()
         viewModel.agreementRelay
             .subscribe(onNext: { [weak self] _ in
-                self?.termStackView.didAgree.accept(.personal)
+                if false == self?.viewModel.isEnableSignUp ?? false {
+                    self?.termStackView.didAgree.accept(.personal)
+                }
             })
             .disposed(by: disposeBag)
         let viewController = TermDetailViewController(viewModel)

--- a/HikingClub/Feature/MyPage/MyPageViewModel.swift
+++ b/HikingClub/Feature/MyPage/MyPageViewModel.swift
@@ -69,7 +69,7 @@ final class MyPageViewModel: BaseViewModel {
                 self?.roadRequestFinised.accept(Void())
             }, onError: { [weak self] _ in
                 self?.roadRequestFinised.accept(Void())
-                NDToastView.shared.rx.showText.onNext(.red(text: "네트워크 오류가 발생했습니다."))
+                self?.toastMessage.accept(.red(text: "네트워크 오류가 발생했습니다."))
             })
             .disposed(by: disposeBag)
     }
@@ -113,8 +113,8 @@ final class MyPageViewModel: BaseViewModel {
         userService.profile()
             .subscribe(onSuccess: { [weak self] in
                 self?.userInformation.accept($0.data)
-            }, onFailure: { _ in
-                NDToastView.shared.rx.showText.onNext(.red(text: "네트워크 오류가 발생했습니다."))
+            }, onFailure: { [weak self] _ in
+                self?.toastMessage.accept(.red(text: "네트워크 오류가 발생했습니다."))
             })
             .disposed(by: disposeBag)
     }

--- a/HikingClub/Feature/SelectTown/SelectTownViewModel.swift
+++ b/HikingClub/Feature/SelectTown/SelectTownViewModel.swift
@@ -21,8 +21,8 @@ final class SelectTownViewModel: BaseViewModel {
             .subscribe(onSuccess: { [weak self] response in
                 guard let places = response.listData else { return }
                 self?.processPlaceResponse(places)
-            }, onFailure: { _ in
-                NDToastView.shared.rx.showText.onNext(.red(text: "네트워크 오류가 발생했습니다."))
+            }, onFailure: { [weak self] _ in
+                self?.toastMessage.accept(.red(text: "네트워크 오류가 발생했습니다."))
             })
             .disposed(by: disposeBag)
     }
@@ -40,8 +40,8 @@ final class SelectTownViewModel: BaseViewModel {
             .subscribe(onSuccess: { [weak self] response in
                 guard let places = response.listData else { return }
                 self?.processPlaceResponse(places)
-            }, onFailure: { _ in
-                NDToastView.shared.rx.showText.onNext(.red(text: "네트워크 오류가 발생했습니다."))
+            }, onFailure: { [weak self] _ in
+                self?.toastMessage.accept(.red(text: "네트워크 오류가 발생했습니다."))
             })
             .disposed(by: disposeBag)
     }

--- a/HikingClub/Helper/BaseArchitecture/BaseViewController.swift
+++ b/HikingClub/Helper/BaseArchitecture/BaseViewController.swift
@@ -43,7 +43,19 @@ class BaseViewController<T: BaseViewModel>: UIViewController, CodeBasedProtocol 
     
     func layout() { }
     
-    func bind() { }
+    func bind() {
+        baseBinding()
+    }
+    
+    private func baseBinding() {
+        toastMessageBinding()
+    }
+    
+    private func toastMessageBinding() {
+        viewModel.toastMessage
+            .bind(to: NDToastView.shared.rx.showText)
+            .disposed(by: disposeBag)
+    }
     
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         self.view.endEditing(true)

--- a/HikingClub/Helper/BaseArchitecture/BaseViewModel.swift
+++ b/HikingClub/Helper/BaseArchitecture/BaseViewModel.swift
@@ -7,7 +7,9 @@
 
 import Foundation
 import RxSwift
+import RxRelay
 
 class BaseViewModel: NSObject {
     let disposeBag = DisposeBag()
+    let toastMessage = PublishRelay<NDToastView.Theme>()
 }


### PR DESCRIPTION
<!-- 필요하지 않은 항목 삭제하기 -->
## 이슈번호
#79 
## 작업내용 
* ViewModel에서 직접 NDToastView를 사용하지 않도록 변경
## 변경사항
* ViewModel에서 NDToastView.Theme를 전달하고, ViewController에서 NDToastView를 노출하도록 변경

## 참고사항
branch를 bugfix에서 [bugfix/sh/#112](https://github.com/mash-up-kr/HikingClub_iOS/tree/bugfix/sh/%23112)에서 따버렸네요.... 😢 
https://github.com/mash-up-kr/HikingClub_iOS/pull/115/commits/3644adf1384eac9555fcff76582e41d7ec6f3ae6 커밋부터 리뷰 부탁드립니다 😭 
