### PR TITLE
:recycle: 이미지 레이아웃 개선

### DIFF
--- a/HikingClub/Feature/Home/HomeViewController.swift
+++ b/HikingClub/Feature/Home/HomeViewController.swift
@@ -63,7 +63,7 @@ final class HomeViewController: BaseViewController<HomeViewModel> {
         viewModel.roadDatas
             .bind(to: tableView.rx.items(cellIdentifier: "RoadTableViewCell",
                                          cellType: RoadTableViewCell.self)) { row, cellModel, cell in
-                cell.configure(model: cellModel, delegate: self)
+                cell.configure(model: cellModel)
             }.disposed(by: disposeBag)
         
         viewModel.roadDatas
@@ -211,11 +211,5 @@ extension HomeViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         let word = viewModel.locations.value[indexPath.item].addressDong
         return locationTabbar.cellSize(title: word, subTitle: indexPath.item == 0 ? "현위치" : nil)
-    }
-}
-
-extension HomeViewController: RoadTableViewImageDelegate {
-    func didUpdate() {
-        tableView.performBatchUpdates(nil)
     }
 }

--- a/HikingClub/Feature/Home/View/Road/TableViewCell/RoadTableViewCell.swift
+++ b/HikingClub/Feature/Home/View/Road/TableViewCell/RoadTableViewCell.swift
@@ -8,10 +8,6 @@
 import UIKit
 import Kingfisher
 
-protocol RoadTableViewImageDelegate: AnyObject {
-    func didUpdate()
-}
-
 final class RoadTableViewCell: UITableViewCell {
     
     @IBOutlet private weak var titleStackView: UIStackView!
@@ -44,7 +40,7 @@ final class RoadTableViewCell: UITableViewCell {
         setRoadImageViewHidden(true)
     }
     
-    func configure(model: Road, delegate: RoadTableViewImageDelegate? = nil) {
+    func configure(model: Road) {
         self.model = model
         roadTitleLabel.text = model.title
         setRoadDistanceLabel(distance: model.distance)
@@ -55,9 +51,7 @@ final class RoadTableViewCell: UITableViewCell {
         let imageURL = URL(string: imageString) {
             setRoadImageViewHidden(false)
             roadImageView.kf.indicatorType = .activity
-            roadImageView.kf.setImage(with: imageURL, options: [.cacheMemoryOnly]) { _ in
-                delegate?.didUpdate()
-            }
+            roadImageView.kf.setImage(with: imageURL, options: [.cacheMemoryOnly, .transition(.fade(0.5))])
         }
         settingRoadHashTagStackView(model.hashtags)
     }

--- a/HikingClub/Feature/Home/View/Road/TableViewCell/RoadTableViewCell.xib
+++ b/HikingClub/Feature/Home/View/Road/TableViewCell/RoadTableViewCell.xib
@@ -26,13 +26,16 @@
                                 <rect key="frame" x="16" y="16" width="376" height="234"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="MiL-Uw-ekf">
-                                        <rect key="frame" x="0.0" y="0.0" width="376" height="102.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="376" height="104"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="104" id="AaQ-ac-Dee"/>
+                                        </constraints>
                                     </imageView>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HF2-Gr-a6E">
-                                        <rect key="frame" x="0.0" y="119.5" width="376" height="114.5"/>
+                                        <rect key="frame" x="0.0" y="121" width="376" height="113"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VDv-2n-oSG">
-                                                <rect key="frame" x="296" y="81" width="80" height="20"/>
+                                                <rect key="frame" x="296" y="79.5" width="80" height="20"/>
                                                 <color key="backgroundColor" systemColor="systemYellowColor"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="80" id="wmE-Xh-sf4"/>
@@ -40,39 +43,39 @@
                                                 </constraints>
                                             </view>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="단풍나무 산책길" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0l5-Ra-rbu">
-                                                <rect key="frame" x="0.0" y="0.0" width="101" height="19.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="101" height="18"/>
                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="16"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon_footprint_green500_16" translatesAutoresizingMaskIntoConstraints="NO" id="cxs-3c-ioW">
-                                                <rect key="frame" x="0.0" y="27.5" width="16" height="16"/>
+                                                <rect key="frame" x="0.0" y="26" width="16" height="16"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="16" id="VLl-YK-gNc"/>
                                                     <constraint firstAttribute="height" constant="16" id="biz-fS-tyl"/>
                                                 </constraints>
                                             </imageView>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon_location_green500_16" translatesAutoresizingMaskIntoConstraints="NO" id="ORW-un-ed5">
-                                                <rect key="frame" x="0.0" y="51.5" width="16" height="16"/>
+                                                <rect key="frame" x="0.0" y="50" width="16" height="16"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="16" id="ppE-b1-2AC"/>
                                                     <constraint firstAttribute="height" constant="16" id="qj7-DI-Nhx"/>
                                                 </constraints>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0.8km (11분)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4wV-JM-f4g">
-                                                <rect key="frame" x="20" y="27.5" width="79.5" height="16"/>
+                                                <rect key="frame" x="20" y="26" width="79.5" height="16"/>
                                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="13"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="서울 송파구 위례성대로 134 (방이동)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LoQ-lc-Rid">
-                                                <rect key="frame" x="20" y="51.5" width="193" height="16"/>
+                                                <rect key="frame" x="20" y="50" width="193" height="16"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="A6i-oV-Ofn">
-                                                <rect key="frame" x="107.5" y="25.5" width="104" height="20"/>
+                                                <rect key="frame" x="107.5" y="24" width="104" height="20"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon_star_yellow500_16" translatesAutoresizingMaskIntoConstraints="NO" id="NlF-5A-m1h">
                                                         <rect key="frame" x="2" y="2" width="16" height="16"/>
@@ -100,14 +103,14 @@
                                                 </constraints>
                                             </view>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="jn1-ZO-RIg">
-                                                <rect key="frame" x="0.0" y="79.5" width="0.0" height="23"/>
+                                                <rect key="frame" x="0.0" y="78" width="0.0" height="23"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="23" id="CsV-Tn-qKZ"/>
                                                     <constraint firstAttribute="width" id="vKW-3l-Oo1"/>
                                                 </constraints>
                                             </stackView>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1gF-D6-wVH">
-                                                <rect key="frame" x="352" y="-2" width="24" height="24"/>
+                                                <rect key="frame" x="352" y="-3" width="24" height="24"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="24" id="2f4-KT-BmB"/>
                                                     <constraint firstAttribute="height" constant="24" id="zZm-My-KLL"/>

--- a/HikingClub/Feature/Search/SearchCategoryResultViewController.swift
+++ b/HikingClub/Feature/Search/SearchCategoryResultViewController.swift
@@ -171,7 +171,7 @@ final class SearchCategoryResultViewController: BaseViewController<SearchCategor
         viewModel.roadDatas
             .bind(to: tableView.rx.items(cellIdentifier: "RoadTableViewCell",
                                          cellType: RoadTableViewCell.self)) { row, cellModel, cell in
-                cell.configure(model: cellModel, delegate: self)
+                cell.configure(model: cellModel)
             }.disposed(by: disposeBag)
         
         tableView.rx.itemSelected
@@ -208,11 +208,5 @@ extension SearchCategoryResultViewController: UICollectionViewDelegateFlowLayout
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         let word = viewModel.categoryWords.value[indexPath.item].name
         return categoryCollectionView.cellSize(title: word)
-    }
-}
-
-extension SearchCategoryResultViewController: RoadTableViewImageDelegate {
-    func didUpdate() {
-        tableView.performBatchUpdates(nil)
     }
 }


### PR DESCRIPTION
<!-- 필요하지 않은 항목 삭제하기 -->
## 이슈번호
#109

## 작업내용 
* 레이아웃 업데이트시 늘어나는 효과가 부자연스러움 -> 스텍뷰에 있는 이미지뷰에 height고정해서 미리 늘어나도록함
* fade효과적용